### PR TITLE
Safer cache clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,8 +373,17 @@ Common error cases:
 
 - Default: 1 hour for all endpoints except --full
 - `--full`: Always 24 hours (cannot be disabled)
-- Location: `~/.local/state/eol/` (configurable)
-- Format: JSON files with expiration metadata
+- Location: `~/.cache/eol/` (configurable with `--cache-dir`)
+- Format: `.eol_cache.json` files with expiration metadata
+
+**Cache safety:**
+
+The `cache clear` command includes multiple safety layers:
+
+- Only works if the final folder name is exactly: `.eol-cache`, `eol-cache`, or `eol`
+- Only removes `*.eol_cache.json` files (no subfolders affected)
+- Will conservatively refuse to clear folders that do not look like our own cache folder
+- Example safe paths: `~/.cache/eol`, `/var/cache/eol-cache`, `/tmp/.eol-cache`
 
 ## Template Functions
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -2,6 +2,7 @@ package eol
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,322 +13,36 @@ import (
 func TestNewCacheManager(t *testing.T) {
 	t.Parallel()
 
-	// Test with custom directory.
-	cm := NewCacheManager("/tmp/test-cache", true, 2*time.Hour)
-	if cm.baseDir != "/tmp/test-cache" {
-		t.Errorf("Expected baseDir '/tmp/test-cache', got '%s'", cm.baseDir)
-	}
-
-	if !cm.enabled {
-		t.Error("Expected cache to be enabled")
-	}
-
-	if cm.defaultTTL != 2*time.Hour {
-		t.Errorf("Expected defaultTTL 2h, got %v", cm.defaultTTL)
-	}
-
-	if cm.fullTTL != 24*time.Hour {
-		t.Errorf("Expected fullTTL 24h, got %v", cm.fullTTL)
-	}
-
-	// Test with empty directory (should use default).
-	cm2 := NewCacheManager("", false, time.Hour)
-	if cm2.baseDir == "" {
-		t.Error("Expected baseDir to be set to default")
-	}
-
-	if cm2.enabled {
-		t.Error("Expected cache to be disabled")
-	}
-}
-
-func TestCacheManagerSetEnabled(t *testing.T) {
-	t.Parallel()
-
-	cm := NewCacheManager("/tmp/test", false, time.Hour)
-	if cm.enabled {
-		t.Error("Expected cache to be disabled initially")
-	}
-
-	cm.SetEnabled(true)
-
-	if !cm.enabled {
-		t.Error("Expected cache to be enabled after SetEnabled(true)")
-	}
-}
-
-func TestCacheManagerSetDefaultTTL(t *testing.T) {
-	t.Parallel()
-
-	cm := NewCacheManager("/tmp/test", true, time.Hour)
-	if cm.defaultTTL != time.Hour {
-		t.Errorf("Expected initial TTL 1h, got %v", cm.defaultTTL)
-	}
-
-	cm.SetDefaultTTL(30 * time.Minute)
-
-	if cm.defaultTTL != 30*time.Minute {
-		t.Errorf("Expected TTL 30m, got %v", cm.defaultTTL)
-	}
-}
-
-func TestCacheManagerGenerateCacheKey(t *testing.T) {
-	t.Parallel()
-
-	cm := NewCacheManager("/tmp/test", true, time.Hour)
-
 	//nolint:govet // ok
 	tests := []struct {
-		endpoint string
-		params   []string
-		expected string
-	}{
-		{"products", nil, "products.json"},
-		{"/products", nil, "products.json"},
-		{"products/full", nil, "products-full.json"},
-		{"/products/ubuntu", nil, "products-ubuntu.json"},
-		{"products", []string{"param1"}, "products-a2cbb63a.json"},
-		{"products", []string{"param1"}, "products-a2cbb63a.json"}, // MD5 hash of "param1".
-	}
-
-	for _, test := range tests {
-		result := cm.generateCacheKey(test.endpoint, test.params...)
-		if result != test.expected {
-			t.Errorf("generateCacheKey(%s, %v) = %s, expected %s", test.endpoint, test.params, result, test.expected)
-		}
-	}
-}
-
-func TestCacheManagerIsFullEndpoint(t *testing.T) {
-	t.Parallel()
-
-	cm := NewCacheManager("/tmp/test", true, time.Hour)
-
-	tests := []struct {
-		endpoint string
-		expected bool
-	}{
-		{"/products/full", true},
-		{"products/full", true},
-		{"/products", false},
-		{"products", false},
-		{"/categories", false},
-	}
-
-	for _, test := range tests {
-		result := cm.isFullEndpoint(test.endpoint)
-		if result != test.expected {
-			t.Errorf("isFullEndpoint(%s) = %t, expected %t", test.endpoint, result, test.expected)
-		}
-	}
-}
-
-//nolint:paralleltest // TempDir
-func TestCacheManagerSetAndGet(t *testing.T) {
-	cm := NewCacheManager(t.TempDir(), true, time.Hour)
-	testData := map[string]any{
-		"test": "value",
-		"num":  42,
-	}
-
-	err := cm.Set("test-endpoint", testData)
-	if err != nil {
-		t.Fatalf("Failed to set cache: %v", err)
-	}
-
-	cached, found := cm.Get("test-endpoint")
-	if !found {
-		t.Fatal("Expected to find cached data")
-	}
-
-	var cachedMap map[string]any
-
-	if err = json.Unmarshal(cached, &cachedMap); err != nil {
-		t.Fatalf("Failed to unmarshal cached data: %v", err)
-	}
-
-	if cachedMap["test"] != "value" {
-		t.Errorf("Expected test='value', got %v", cachedMap["test"])
-	}
-
-	if cachedMap["num"] != float64(42) {
-		t.Errorf("Expected num=42, got %v", cachedMap["num"])
-	}
-}
-
-//nolint:paralleltest // TempDir
-func TestCacheManagerGetNonExistent(t *testing.T) {
-	cm := NewCacheManager(t.TempDir(), true, time.Hour)
-
-	_, found := cm.Get("non-existent")
-	if found {
-		t.Error("Expected not to find non-existent cache")
-	}
-}
-
-//nolint:paralleltest // TempDir
-func TestCacheManagerExpiredCache(t *testing.T) {
-	cm := NewCacheManager(t.TempDir(), true, 10*time.Millisecond)
-	testData := map[string]any{"test": "value"}
-
-	err := cm.Set("test-endpoint", testData)
-	if err != nil {
-		t.Fatalf("Failed to set cache: %v", err)
-	}
-
-	time.Sleep(20 * time.Millisecond)
-
-	_, found := cm.Get("test-endpoint")
-	if found {
-		t.Error("Expected not to find expired cache")
-	}
-}
-
-//nolint:paralleltest // TempDir
-func TestCacheManagerDisabledCache(t *testing.T) {
-	cm := NewCacheManager(t.TempDir(), false, time.Hour)
-	testData := map[string]any{"test": "value"}
-
-	err := cm.Set("test-endpoint", testData)
-	if err != nil {
-		t.Fatalf("Set should not error when disabled: %v", err)
-	}
-
-	_, found := cm.Get("test-endpoint")
-	if found {
-		t.Error("Expected not to find cache when disabled")
-	}
-}
-
-//nolint:paralleltest // TempDir
-func TestCacheManagerFullEndpointAlwaysCached(t *testing.T) {
-	cm := NewCacheManager(t.TempDir(), false, time.Hour)
-	testData := map[string]any{"test": "full"}
-
-	err := cm.Set("products/full", testData)
-	if err != nil {
-		t.Fatalf("Failed to set cache for full endpoint: %v", err)
-	}
-
-	cached, found := cm.Get("products/full")
-	if !found {
-		t.Error("Expected to find cache for full endpoint even when disabled")
-	}
-
-	var cachedMap map[string]any
-
-	if err = json.Unmarshal(cached, &cachedMap); err != nil {
-		t.Fatalf("Failed to unmarshal cached data: %v", err)
-	}
-
-	if cachedMap["test"] != "full" {
-		t.Errorf("Expected test='full', got %v", cachedMap["test"])
-	}
-}
-
-//nolint:paralleltest // TempDir
-func TestCacheManagerClear(t *testing.T) {
-	cm := NewCacheManager(t.TempDir(), true, time.Hour)
-	testData := map[string]any{"test": "value"}
-
-	err := cm.Set("test-endpoint", testData)
-	if err != nil {
-		t.Fatalf("Failed to set cache: %v", err)
-	}
-
-	_, found := cm.Get("test-endpoint")
-	if !found {
-		t.Fatal("Expected to find cached data before clear")
-	}
-
-	err = cm.Clear()
-	if err != nil {
-		t.Fatalf("Failed to clear cache: %v", err)
-	}
-
-	_, found = cm.Get("test-endpoint")
-	if found {
-		t.Error("Expected not to find cache after clear")
-	}
-}
-
-//nolint:paralleltest // TempDir
-func TestCacheManagerClearExpired(t *testing.T) {
-	tempDir := t.TempDir()
-	cm := NewCacheManager(tempDir, true, time.Hour)
-	validData := map[string]any{"valid": "data"}
-
-	err := cm.Set("valid-endpoint", validData)
-	if err != nil {
-		t.Fatalf("Failed to set valid cache: %v", err)
-	}
-
-	expiredEntry := CacheEntry{
-		Timestamp: time.Now().Add(-2 * time.Hour),
-		ExpiresAt: time.Now().Add(-time.Hour),
-		Data:      json.RawMessage(`{"expired": true}`),
-		Endpoint:  "expired-endpoint",
-	}
-
-	expiredJSON, err := json.MarshalIndent(expiredEntry, "", "  ")
-	if err != nil {
-		t.Fatalf("Failed to marshal expired entry: %v", err)
-	}
-
-	expiredFile := filepath.Join(tempDir, "expired-endpoint.json")
-
-	err = os.WriteFile(expiredFile, expiredJSON, 0o644)
-	if err != nil {
-		t.Fatalf("Failed to write expired cache file: %v", err)
-	}
-
-	err = cm.ClearExpired()
-	if err != nil {
-		t.Fatalf("Failed to clear expired: %v", err)
-	}
-
-	_, found := cm.Get("valid-endpoint")
-	if !found {
-		t.Error("Expected valid cache to still exist")
-	}
-
-	if _, err = os.Stat(expiredFile); !os.IsNotExist(err) {
-		t.Error("Expected expired cache file to be removed")
-	}
-}
-
-func TestNewCacheManagerComprehensive(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		expectedResult func(*CacheManager) bool
 		name           string
 		baseDir        string
-		defaultTTL     time.Duration
 		enabled        bool
+		defaultTTL     time.Duration
+		expectedResult func(*CacheManager) bool
 	}{
 		{
-			name:       "custom base directory",
-			baseDir:    "/custom/cache/dir",
+			name:       "custom directory enabled",
+			baseDir:    "/tmp/test-cache",
 			enabled:    true,
-			defaultTTL: time.Hour,
+			defaultTTL: 2 * time.Hour,
 			expectedResult: func(cm *CacheManager) bool {
-				return cm.baseDir == "/custom/cache/dir" &&
+				return cm.baseDir == "/tmp/test-cache" &&
 					cm.enabled == true &&
-					cm.defaultTTL == time.Hour &&
+					cm.defaultTTL == 2*time.Hour &&
 					cm.fullTTL == 24*time.Hour
 			},
 		},
 		{
-			name:       "disabled cache",
+			name:       "empty directory disabled",
 			baseDir:    "",
 			enabled:    false,
-			defaultTTL: 30 * time.Minute,
+			defaultTTL: time.Hour,
 			expectedResult: func(cm *CacheManager) bool {
-				return !cm.enabled &&
-					cm.defaultTTL == 30*time.Minute &&
-					cm.fullTTL == 24*time.Hour &&
-					cm.baseDir != ""
+				return cm.baseDir != "" &&
+					cm.enabled == false &&
+					cm.defaultTTL == time.Hour &&
+					cm.fullTTL == 24*time.Hour
 			},
 		},
 		{
@@ -340,6 +55,41 @@ func TestNewCacheManagerComprehensive(t *testing.T) {
 					cm.enabled == true &&
 					cm.defaultTTL == 0 &&
 					cm.fullTTL == 24*time.Hour
+			},
+		},
+		{
+			name:       "negative TTL",
+			baseDir:    "/tmp/cache",
+			enabled:    true,
+			defaultTTL: -time.Hour,
+			expectedResult: func(cm *CacheManager) bool {
+				return cm.baseDir == "/tmp/cache" &&
+					cm.enabled == true &&
+					cm.defaultTTL == -time.Hour &&
+					cm.fullTTL == 24*time.Hour
+			},
+		},
+		{
+			name:       "default path validation",
+			baseDir:    "",
+			enabled:    true,
+			defaultTTL: 30 * time.Minute,
+			expectedResult: func(cm *CacheManager) bool {
+				expectedPatterns := []string{"eol", "cache"}
+				found := false
+
+				for _, pattern := range expectedPatterns {
+					if strings.Contains(strings.ToLower(cm.baseDir), pattern) {
+						found = true
+						break
+					}
+				}
+
+				return cm.baseDir != "" &&
+					cm.enabled == true &&
+					cm.defaultTTL == 30*time.Minute &&
+					cm.fullTTL == 24*time.Hour &&
+					found
 			},
 		},
 	}
@@ -365,64 +115,114 @@ func TestNewCacheManagerComprehensive(t *testing.T) {
 	}
 }
 
-func TestNewCacheManagerDefaultPaths(t *testing.T) {
+func TestCacheManagerGenerateCacheKey(t *testing.T) {
 	t.Parallel()
 
-	// Test that empty baseDir results in a non-empty path.
-	cm := NewCacheManager("", true, time.Hour)
+	cm := NewCacheManager("/tmp/test", true, time.Hour)
 
-	if cm.baseDir == "" {
-		t.Error("baseDir should not be empty when default path is used")
+	//nolint:govet // ok
+	tests := []struct {
+		name     string
+		endpoint string
+		params   []string
+		expected string
+	}{
+		{
+			name:     "simple endpoint no params",
+			endpoint: "products",
+			params:   nil,
+			expected: "products" + cacheExt,
+		},
+		{
+			name:     "endpoint with leading slash",
+			endpoint: "/products",
+			params:   nil,
+			expected: "products" + cacheExt,
+		},
+		{
+			name:     "full endpoint",
+			endpoint: "products/full",
+			params:   nil,
+			expected: "products-full" + cacheExt,
+		},
+		{
+			name:     "product endpoint",
+			endpoint: "/products/ubuntu",
+			params:   nil,
+			expected: "products-ubuntu" + cacheExt,
+		},
+		{
+			name:     "endpoint with params",
+			endpoint: "products",
+			params:   []string{"param1"},
+			expected: "products-a2cbb63a" + cacheExt,
+		},
+		{
+			name:     "consistent param hashing",
+			endpoint: "products",
+			params:   []string{"param1"},
+			expected: "products-a2cbb63a" + cacheExt,
+		},
 	}
 
-	// The exact path depends on the OS and user's home directory,
-	// but it should contain some expected patterns.
-	expectedPatterns := []string{"eol", "cache"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	found := false
-
-	for _, pattern := range expectedPatterns {
-		if strings.Contains(strings.ToLower(cm.baseDir), pattern) {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		t.Errorf("baseDir %q should contain one of %v", cm.baseDir, expectedPatterns)
+			result := cm.generateCacheKey(tt.endpoint, tt.params...)
+			if result != tt.expected {
+				t.Errorf("generateCacheKey(%s, %v) = %s, expected %s", tt.endpoint, tt.params, result, tt.expected)
+			}
+		})
 	}
 }
 
-//nolint:paralleltest // TempDir
-func TestCacheManagerGetStats(t *testing.T) {
-	tempDir := t.TempDir()
-	cm := NewCacheManager(tempDir, true, time.Hour)
-	testData := map[string]any{"test": "value"}
+func TestCacheManagerIsFullEndpoint(t *testing.T) {
+	t.Parallel()
 
-	err := cm.Set("test-endpoint", testData)
-	if err != nil {
-		t.Fatalf("Failed to set cache: %v", err)
+	cm := NewCacheManager("/tmp/test", true, time.Hour)
+
+	tests := []struct {
+		name     string
+		endpoint string
+		expected bool
+	}{
+		{
+			name:     "full endpoint with slash",
+			endpoint: "/products/full",
+			expected: true,
+		},
+		{
+			name:     "full endpoint without slash",
+			endpoint: "products/full",
+			expected: true,
+		},
+		{
+			name:     "products endpoint with slash",
+			endpoint: "/products",
+			expected: false,
+		},
+		{
+			name:     "products endpoint without slash",
+			endpoint: "products",
+			expected: false,
+		},
+		{
+			name:     "categories endpoint",
+			endpoint: "/categories",
+			expected: false,
+		},
 	}
 
-	stats, err := cm.GetStats()
-	if err != nil {
-		t.Fatalf("Failed to get stats: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if stats.Enabled != true {
-		t.Errorf("Expected enabled=true, got %v", stats.Enabled)
-	}
-
-	if stats.CacheDir != tempDir {
-		t.Errorf("Expected cache_dir=%s, got %v", tempDir, stats.CacheDir)
-	}
-
-	if stats.TotalFiles < 1 {
-		t.Errorf("Expected at least 1 total file, got %v", stats.TotalFiles)
-	}
-
-	if stats.ValidFiles < 1 {
-		t.Errorf("Expected at least 1 valid file, got %v", stats.ValidFiles)
+			result := cm.isFullEndpoint(tt.endpoint)
+			if result != tt.expected {
+				t.Errorf("isFullEndpoint(%s) = %t, expected %t", tt.endpoint, result, tt.expected)
+			}
+		})
 	}
 }
 
@@ -430,27 +230,478 @@ func TestCacheManagerMustUseCache(t *testing.T) {
 	t.Parallel()
 
 	cm := NewCacheManager("/tmp/test", true, time.Hour)
+
 	tests := []struct {
+		name     string
 		endpoint string
 		expected bool
 	}{
-		{"/products/full", true},
-		{"products/full", true},
-		{"/products", false},
-		{"products", false},
+		{
+			name:     "full endpoint with slash",
+			endpoint: "/products/full",
+			expected: true,
+		},
+		{
+			name:     "full endpoint without slash",
+			endpoint: "products/full",
+			expected: true,
+		},
+		{
+			name:     "products endpoint with slash",
+			endpoint: "/products",
+			expected: false,
+		},
+		{
+			name:     "products endpoint without slash",
+			endpoint: "products",
+			expected: false,
+		},
 	}
 
-	for _, test := range tests {
-		result := cm.MustUseCache(test.endpoint)
-		if result != test.expected {
-			t.Errorf("MustUseCache(%s) = %t, expected %t", test.endpoint, result, test.expected)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := cm.MustUseCache(tt.endpoint)
+			if result != tt.expected {
+				t.Errorf("MustUseCache(%s) = %t, expected %t", tt.endpoint, result, tt.expected)
+			}
+		})
 	}
 }
 
-func TestCacheManagerGetReleaseFromProductCache(t *testing.T) {
-	t.Parallel()
+//nolint:paralleltest // t.TempDir
+func TestCacheManagerSetAndGet(t *testing.T) {
+	//nolint:govet // ok
+	tests := []struct {
+		name           string
+		enabled        bool
+		endpoint       string
+		ttl            time.Duration
+		sleep          time.Duration
+		testData       map[string]any
+		expectedFound  bool
+		expectSetError bool
+	}{
+		{
+			name:          "successful set and get",
+			enabled:       true,
+			endpoint:      "test-endpoint",
+			ttl:           time.Hour,
+			testData:      map[string]any{"test": "value", "num": 42},
+			expectedFound: true,
+		},
+		{
+			name:          "non-existent cache",
+			enabled:       true,
+			endpoint:      "non-existent",
+			ttl:           time.Hour,
+			testData:      nil,
+			expectedFound: false,
+		},
+		{
+			name:          "expired cache",
+			enabled:       true,
+			endpoint:      "test-endpoint",
+			ttl:           10 * time.Millisecond,
+			sleep:         20 * time.Millisecond,
+			testData:      map[string]any{"test": "value"},
+			expectedFound: false,
+		},
+		{
+			name:          "disabled cache regular endpoint",
+			enabled:       false,
+			endpoint:      "test-endpoint",
+			ttl:           time.Hour,
+			testData:      map[string]any{"test": "value"},
+			expectedFound: false,
+		},
+		{
+			name:          "disabled cache full endpoint",
+			enabled:       false,
+			endpoint:      "products/full",
+			ttl:           time.Hour,
+			testData:      map[string]any{"test": "full"},
+			expectedFound: true,
+		},
+	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := NewCacheManager(t.TempDir(), tt.enabled, tt.ttl)
+
+			if tt.testData != nil {
+				err := cm.Set(tt.endpoint, tt.testData)
+				if tt.expectSetError && err == nil {
+					t.Error("Expected set error but got none")
+				} else if !tt.expectSetError && err != nil {
+					t.Fatalf("Failed to set cache: %v", err)
+				}
+			}
+
+			if tt.sleep > 0 {
+				time.Sleep(tt.sleep)
+			}
+
+			cached, found := cm.Get(tt.endpoint)
+			if found != tt.expectedFound {
+				t.Errorf("Expected found=%v, got %v", tt.expectedFound, found)
+				return
+			}
+
+			if found && tt.testData != nil { //nolint:nestif // ok
+				var cachedMap map[string]any
+				if err := json.Unmarshal(cached, &cachedMap); err != nil {
+					t.Fatalf("Failed to unmarshal cached data: %v", err)
+				}
+
+				for key, expected := range tt.testData {
+					if key == "num" {
+						if cachedMap[key] != float64(expected.(int)) {
+							t.Errorf("Expected %s=%v, got %v", key, float64(expected.(int)), cachedMap[key])
+						}
+					} else if cachedMap[key] != expected {
+						t.Errorf("Expected %s=%v, got %v", key, expected, cachedMap[key])
+					}
+				}
+			}
+		})
+	}
+}
+
+//nolint:paralleltest,tparallel // t.TempDir
+func TestCacheManagerClear(t *testing.T) {
+	//nolint:govet // ok
+	tests := []struct {
+		name        string
+		baseDir     string
+		expectError bool
+		errorType   error
+		setupData   bool
+	}{
+		{
+			name:      "successful clear allowed path",
+			baseDir:   "eol-cache",
+			setupData: true,
+		},
+		{
+			name:      "successful clear dot eol cache",
+			baseDir:   ".eol-cache",
+			setupData: true,
+		},
+		{
+			name:      "successful clear eol path",
+			baseDir:   "eol",
+			setupData: true,
+		},
+		{
+			name:        "refuse dangerous path fake root",
+			baseDir:     "/fake_root_that_does_not_exist",
+			expectError: true,
+			errorType:   errRefusingToClear,
+		},
+		{
+			name:        "refuse dangerous path fake home",
+			baseDir:     "/home/fake_user_that_does_not_exist",
+			expectError: true,
+			errorType:   errRefusingToClear,
+		},
+		{
+			name:        "refuse dangerous path system dir",
+			baseDir:     "/usr/fake_system_dir",
+			expectError: true,
+			errorType:   errRefusingToClear,
+		},
+		{
+			name:        "refuse random temp dir",
+			expectError: true,
+			errorType:   errRefusingToClear,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			baseDir := tt.baseDir
+			if tt.name == "refuse random temp dir" {
+				baseDir = t.TempDir()
+			} else if tt.baseDir != "" && !strings.HasPrefix(tt.baseDir, "/") {
+				baseDir = filepath.Join(t.TempDir(), tt.baseDir)
+			}
+
+			cm := NewCacheManager(baseDir, true, time.Hour)
+
+			if tt.setupData {
+				testData := map[string]any{"test": "data"}
+				if err := cm.Set("test-endpoint", testData); err != nil {
+					t.Fatalf("Failed to set test data: %v", err)
+				}
+
+				_, found := cm.Get("test-endpoint")
+				if !found {
+					t.Fatal("Expected to find test data before clear")
+				}
+			}
+
+			err := cm.Clear()
+			if tt.expectError { //nolint:nestif // ok
+				if err == nil {
+					t.Errorf("Expected error when trying to clear path: %s", baseDir)
+				} else if tt.errorType != nil && !errors.Is(err, tt.errorType) {
+					t.Errorf("Expected error %v, got: %v", tt.errorType, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no error for allowed path %s, got: %v", baseDir, err)
+				}
+
+				if tt.setupData {
+					if _, found := cm.Get("test-endpoint"); found {
+						t.Error("Expected cache to be cleared")
+					}
+				}
+			}
+		})
+	}
+}
+
+//nolint:paralleltest // t.TempDir
+func TestCacheManagerClearExpired(t *testing.T) {
+	//nolint:govet // ok
+	tests := []struct {
+		name        string
+		enabled     bool
+		setupFunc   func(*testing.T, *CacheManager) error
+		expectError bool
+	}{
+		{
+			name:    "empty cache directory",
+			enabled: true,
+			setupFunc: func(t *testing.T, cm *CacheManager) error {
+				t.Helper()
+				return nil
+			},
+		},
+		{
+			name:    "disabled cache",
+			enabled: false,
+			setupFunc: func(t *testing.T, cm *CacheManager) error {
+				t.Helper()
+				return nil
+			},
+		},
+		{
+			name:    "valid and expired entries",
+			enabled: true,
+			setupFunc: func(t *testing.T, cm *CacheManager) error {
+				t.Helper()
+
+				validData := map[string]any{"valid": "data"}
+				if err := cm.Set("valid-endpoint", validData); err != nil {
+					return err
+				}
+
+				expiredEntry := CacheEntry{
+					Timestamp: time.Now().Add(-2 * time.Hour),
+					ExpiresAt: time.Now().Add(-time.Hour),
+					Data:      json.RawMessage(`{"expired": true}`),
+					Endpoint:  "expired-endpoint",
+				}
+
+				expiredJSON, err := json.MarshalIndent(expiredEntry, "", "  ")
+				if err != nil {
+					return err
+				}
+
+				expiredFile := filepath.Join(cm.baseDir, "expired"+cacheExt)
+
+				return os.WriteFile(expiredFile, expiredJSON, 0o644)
+			},
+		},
+		{
+			name:    "cache with negative TTL entries",
+			enabled: true,
+			setupFunc: func(t *testing.T, cm *CacheManager) error {
+				t.Helper()
+
+				negativeTTLCM := NewCacheManager(cm.baseDir, true, -time.Hour)
+
+				testData := map[string]any{"test": "data"}
+				if err := negativeTTLCM.Set("test1", testData); err != nil {
+					return err
+				}
+
+				return negativeTTLCM.Set("test2", testData)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := filepath.Join(t.TempDir(), "eol-cache")
+			cm := NewCacheManager(tempDir, tt.enabled, time.Hour)
+
+			if err := tt.setupFunc(t, cm); err != nil {
+				t.Fatalf("Setup failed: %v", err)
+			}
+
+			err := cm.ClearExpired()
+			if tt.expectError { //nolint:nestif // ok
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ClearExpired failed: %v", err)
+				}
+
+				if tt.name == "valid and expired entries" {
+					_, found := cm.Get("valid-endpoint")
+					if !found {
+						t.Error("Expected valid cache to still exist")
+					}
+
+					expiredFile := filepath.Join(tempDir, "expired"+cacheExt)
+					if _, err = os.Stat(expiredFile); !os.IsNotExist(err) {
+						t.Error("Expected expired cache file to be removed")
+					}
+				}
+			}
+		})
+	}
+}
+
+//nolint:paralleltest // t.TempDir
+func TestCacheManagerGetStats(t *testing.T) {
+	//nolint:govet // ok
+	tests := []struct {
+		name         string
+		enabled      bool
+		setupFunc    func(*testing.T, *CacheManager)
+		validateFunc func(*testing.T, CacheStats)
+	}{
+		{
+			name:      "disabled cache",
+			enabled:   false,
+			setupFunc: func(t *testing.T, cm *CacheManager) { t.Helper() },
+			validateFunc: func(t *testing.T, stats CacheStats) {
+				t.Helper()
+
+				if stats.Enabled != false {
+					t.Errorf("Expected enabled=false, got %v", stats.Enabled)
+				}
+
+				if stats.TotalFiles != 0 {
+					t.Errorf("Expected 0 files for disabled cache, got %d", stats.TotalFiles)
+				}
+			},
+		},
+		{
+			name:      "empty cache directory",
+			enabled:   true,
+			setupFunc: func(t *testing.T, cm *CacheManager) { t.Helper() },
+			validateFunc: func(t *testing.T, stats CacheStats) {
+				t.Helper()
+
+				if stats.Enabled != true {
+					t.Errorf("Expected enabled=true, got %v", stats.Enabled)
+				}
+
+				if stats.TotalFiles != 0 {
+					t.Errorf("Expected 0 files for empty cache, got %d", stats.TotalFiles)
+				}
+
+				if stats.TotalSize != 0 {
+					t.Errorf("Expected 0 size for empty cache, got %d", stats.TotalSize)
+				}
+			},
+		},
+		{
+			name:    "cache with files",
+			enabled: true,
+			setupFunc: func(t *testing.T, cm *CacheManager) {
+				t.Helper()
+
+				testData := map[string]any{"test": "value"}
+				if err := cm.Set("test-endpoint", testData); err != nil {
+					t.Fatalf("Failed to set cache: %v", err)
+				}
+			},
+			validateFunc: func(t *testing.T, stats CacheStats) {
+				t.Helper()
+
+				if stats.Enabled != true {
+					t.Errorf("Expected enabled=true, got %v", stats.Enabled)
+				}
+
+				if stats.TotalFiles < 1 {
+					t.Errorf("Expected at least 1 total file, got %v", stats.TotalFiles)
+				}
+
+				if stats.ValidFiles < 1 {
+					t.Errorf("Expected at least 1 valid file, got %v", stats.ValidFiles)
+				}
+
+				if stats.TotalSize == 0 {
+					t.Error("Expected non-zero size for cache with files")
+				}
+			},
+		},
+		{
+			name:    "cache with multiple files",
+			enabled: true,
+			setupFunc: func(t *testing.T, cm *CacheManager) {
+				t.Helper()
+
+				testData1 := map[string]any{"test": "data1"}
+				testData2 := map[string]any{"test": "data2"}
+
+				if err := cm.Set("test1", testData1); err != nil {
+					t.Fatalf("Failed to set cache 1: %v", err)
+				}
+
+				if err := cm.Set("test2", testData2); err != nil {
+					t.Fatalf("Failed to set cache 2: %v", err)
+				}
+			},
+			validateFunc: func(t *testing.T, stats CacheStats) {
+				t.Helper()
+
+				if stats.TotalFiles < 2 {
+					t.Errorf("Expected at least 2 files, got %d", stats.TotalFiles)
+				}
+
+				if stats.ValidFiles < 2 {
+					t.Errorf("Expected at least 2 valid files, got %d", stats.ValidFiles)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			cm := NewCacheManager(tempDir, tt.enabled, time.Hour)
+
+			tt.setupFunc(t, cm)
+
+			stats, err := cm.GetStats()
+			if err != nil {
+				t.Fatalf("Failed to get stats: %v", err)
+			}
+
+			if stats.CacheDir != tempDir {
+				t.Errorf("Expected cache_dir=%s, got %v", tempDir, stats.CacheDir)
+			}
+
+			tt.validateFunc(t, stats)
+		})
+	}
+}
+
+//nolint:paralleltest,tparallel // t.TempDir
+func TestCacheManagerGetReleaseFromProductCache(t *testing.T) {
 	productData := map[string]any{
 		"schema_version": "1.2.0",
 		"last_modified":  "2025-01-11T00:00:00Z",
@@ -490,47 +741,75 @@ func TestCacheManagerGetReleaseFromProductCache(t *testing.T) {
 	//nolint:govet // ok
 	tests := []struct {
 		name            string
+		enabled         bool
 		product         string
 		release         string
+		setupCache      bool
 		expectedFound   bool
 		expectedName    string
 		expectedVersion string
 	}{
 		{
 			name:            "existing release",
+			enabled:         true,
 			product:         "go",
 			release:         "1.24",
+			setupCache:      true,
 			expectedFound:   true,
 			expectedName:    "1.24",
 			expectedVersion: "1.2.0",
 		},
 		{
 			name:            "another existing release",
+			enabled:         true,
 			product:         "go",
 			release:         "1.23",
+			setupCache:      true,
 			expectedFound:   true,
 			expectedName:    "1.23",
 			expectedVersion: "1.2.0",
 		},
 		{
 			name:          "non-existent release",
+			enabled:       true,
 			product:       "go",
 			release:       "1.22",
+			setupCache:    true,
 			expectedFound: false,
 		},
 		{
 			name:          "non-existent product",
+			enabled:       true,
 			product:       "nonexistent",
 			release:       "1.0",
+			setupCache:    true,
 			expectedFound: false,
 		},
 		{
 			name:            "version normalization",
+			enabled:         true,
 			product:         "go",
-			release:         "1.23.4", // Should normalize to "1.23".
+			release:         "1.23.4",
+			setupCache:      true,
 			expectedFound:   true,
 			expectedName:    "1.23",
 			expectedVersion: "1.2.0",
+		},
+		{
+			name:          "cache disabled",
+			enabled:       false,
+			product:       "go",
+			release:       "1.24",
+			setupCache:    true,
+			expectedFound: false,
+		},
+		{
+			name:          "no cache data",
+			enabled:       true,
+			product:       "go",
+			release:       "1.24",
+			setupCache:    false,
+			expectedFound: false,
 		},
 	}
 
@@ -538,9 +817,12 @@ func TestCacheManagerGetReleaseFromProductCache(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cm := NewCacheManager(t.TempDir(), true, time.Hour)
-			if err := cm.Set("/products/go", productData, "go"); err != nil {
-				t.Fatalf("Failed to cache product data: %v", err)
+			cm := NewCacheManager(t.TempDir(), tt.enabled, time.Hour)
+
+			if tt.setupCache {
+				if err := cm.Set("/products/go", productData, "go"); err != nil {
+					t.Fatalf("Failed to cache product data: %v", err)
+				}
 			}
 
 			releaseData, found := cm.GetReleaseFromProductCache(tt.product, tt.release)
@@ -554,11 +836,8 @@ func TestCacheManagerGetReleaseFromProductCache(t *testing.T) {
 				return // Test passed - we expected not to find it.
 			}
 
-			// Parse the returned JSON to verify structure.
-			var releaseResponse map[string]any
-
-			err := json.Unmarshal(releaseData, &releaseResponse)
-			if err != nil {
+			releaseResponse := map[string]any{}
+			if err := json.Unmarshal(releaseData, &releaseResponse); err != nil {
 				t.Fatalf("Failed to unmarshal release response: %v", err)
 			}
 
@@ -571,226 +850,106 @@ func TestCacheManagerGetReleaseFromProductCache(t *testing.T) {
 				t.Fatalf("Expected result to be a map, got %T", releaseResponse["result"])
 			}
 
-			if name, ok := result["name"].(string); !ok || name != tt.expectedName { //nolint:govet // ok
+			if name, ok2 := result["name"].(string); !ok2 || name != tt.expectedName {
 				t.Errorf("Expected release name=%s, got %v", tt.expectedName, result["name"])
 			}
 		})
 	}
 }
 
-func TestCacheManagerGetReleaseFromProductCacheCacheDisabled(t *testing.T) {
-	t.Parallel()
-
-	cm := NewCacheManager(t.TempDir(), false, time.Hour) // Cache disabled.
-
-	_, found := cm.GetReleaseFromProductCache("go", "1.24")
-	if found {
-		t.Error("Expected not to find release when cache is disabled")
-	}
-}
-
-func TestNewCacheManagerEdgeCases(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name     string
-		cacheDir string
-		enabled  bool
-		ttl      time.Duration
-	}{
-		{
-			name:     "empty cache dir",
-			cacheDir: "",
-			enabled:  true,
-			ttl:      time.Hour,
-		},
-		{
-			name:     "zero TTL",
-			cacheDir: t.TempDir(),
-			enabled:  true,
-			ttl:      0,
-		},
-		{
-			name:     "disabled cache",
-			cacheDir: t.TempDir(),
-			enabled:  false,
-			ttl:      time.Hour,
-		},
-	}
-
-	for _, tt := range tests {
-		//nolint:staticcheck // ok
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			cm := NewCacheManager(tt.cacheDir, tt.enabled, tt.ttl)
-			if cm == nil {
-				t.Error("Expected non-nil cache manager")
-			}
-
-			if cm.enabled != tt.enabled {
-				t.Errorf("Expected enabled=%v, got %v", tt.enabled, cm.enabled)
-			}
-
-			if cm.defaultTTL != tt.ttl {
-				t.Errorf("Expected TTL=%v, got %v", tt.ttl, cm.defaultTTL)
-			}
-		})
-	}
-}
-
+//nolint:paralleltest,tparallel // t.TempDir
 func TestCacheManagerGetProductFromFullCache(t *testing.T) {
-	t.Parallel()
-
-	cm := NewCacheManager(t.TempDir(), true, time.Hour)
-
-	// Test with no cached data.
-	_, found := cm.GetProductFromFullCache("go")
-	if found {
-		t.Error("Expected not to find product when no cache exists")
+	//nolint:govet // ok
+	tests := []struct {
+		name          string
+		enabled       bool
+		product       string
+		expectedFound bool
+	}{
+		{
+			name:          "no cached data enabled",
+			enabled:       true,
+			product:       "go",
+			expectedFound: false,
+		},
+		{
+			name:          "no cached data disabled",
+			enabled:       false,
+			product:       "go",
+			expectedFound: false,
+		},
 	}
 
-	// Test with disabled cache.
-	cmDisabled := NewCacheManager(t.TempDir(), false, time.Hour)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, found = cmDisabled.GetProductFromFullCache("go")
-	if found {
-		t.Error("Expected not to find product when cache is disabled")
+			cm := NewCacheManager(t.TempDir(), tt.enabled, time.Hour)
+
+			_, found := cm.GetProductFromFullCache(tt.product)
+			if found != tt.expectedFound {
+				t.Errorf("Expected found=%v, got found=%v", tt.expectedFound, found)
+			}
+		})
 	}
 }
 
+//nolint:paralleltest,tparallel // t.TempDir
 func TestCacheManagerGetReleaseFromFullCache(t *testing.T) {
-	t.Parallel()
-
-	cm := NewCacheManager(t.TempDir(), true, time.Hour)
-
-	// Test with no cached data.
-	_, found := cm.GetReleaseFromFullCache("go", "1.24")
-	if found {
-		t.Error("Expected not to find release when no cache exists")
+	//nolint:govet // ok
+	tests := []struct {
+		name          string
+		enabled       bool
+		product       string
+		release       string
+		expectedFound bool
+	}{
+		{
+			name:          "no cached data enabled",
+			enabled:       true,
+			product:       "go",
+			release:       "1.24",
+			expectedFound: false,
+		},
+		{
+			name:          "no cached data disabled",
+			enabled:       false,
+			product:       "go",
+			release:       "1.24",
+			expectedFound: false,
+		},
 	}
 
-	// Test with disabled cache.
-	cmDisabled := NewCacheManager(t.TempDir(), false, time.Hour)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, found = cmDisabled.GetReleaseFromFullCache("go", "1.24")
-	if found {
-		t.Error("Expected not to find release when cache is disabled")
+			cm := NewCacheManager(t.TempDir(), tt.enabled, time.Hour)
+
+			_, found := cm.GetReleaseFromFullCache(tt.product, tt.release)
+			if found != tt.expectedFound {
+				t.Errorf("Expected found=%v, got found=%v", tt.expectedFound, found)
+			}
+		})
 	}
 }
 
+//nolint:paralleltest,tparallel // t.TempDir
 func TestCacheManagerGetProductsFromFullCache(t *testing.T) {
-	t.Parallel()
-
-	cm := NewCacheManager(t.TempDir(), true, time.Hour)
-
-	// Test with no cached data.
-	_, found := cm.GetProductsFromFullCache()
-	if found {
-		t.Error("Expected not to find products when no cache exists")
-	}
-
-	// Test with disabled cache.
-	cmDisabled := NewCacheManager(t.TempDir(), false, time.Hour)
-
-	_, found = cmDisabled.GetProductsFromFullCache()
-	if found {
-		t.Error("Expected not to find products when cache is disabled")
-	}
-}
-
-//nolint:staticcheck // ok
-func TestNewCacheManagerDefaultPath(t *testing.T) {
-	t.Parallel()
-
-	// Test with empty cache dir to trigger default path logic.
-	cm := NewCacheManager("", true, time.Hour)
-	if cm == nil {
-		t.Error("Expected non-nil cache manager")
-	}
-
-	if cm.baseDir == "" {
-		t.Error("Expected non-empty base directory")
-	}
-
-	// Verify it creates the directory structure.
-	if cm.enabled && cm.baseDir != "" {
-		// The cache manager should handle directory creation internally.
-		stats, err := cm.GetStats()
-		if err != nil {
-			t.Errorf("GetStats should work even with default path: %v", err)
-		}
-
-		if stats.TotalFiles < 0 {
-			t.Error("Total files should not be negative")
-		}
-	}
-}
-
-func TestNewCacheManagerComprehensiveEdgeCases(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
-		testFunc func(*testing.T, *CacheManager)
-		name     string
-		cacheDir string
-		ttl      time.Duration
-		enabled  bool
+		name          string
+		enabled       bool
+		expectedFound bool
 	}{
 		{
-			name:     "empty cache dir with user home",
-			cacheDir: "",
-			enabled:  true,
-			ttl:      time.Hour,
-			testFunc: func(t *testing.T, cm *CacheManager) {
-				t.Helper()
-
-				// Should use default cache path.
-				if cm.baseDir == "" {
-					t.Error("Expected non-empty base directory for default path")
-				}
-			},
+			name:          "no cached data enabled",
+			enabled:       true,
+			expectedFound: false,
 		},
 		{
-			name:     "disabled cache manager",
-			cacheDir: t.TempDir(),
-			enabled:  false,
-			ttl:      time.Hour,
-			testFunc: func(t *testing.T, cm *CacheManager) {
-				t.Helper()
-
-				// Test that disabled cache doesn't create directories.
-				_, found := cm.Get("/test")
-				if found {
-					t.Error("Disabled cache should not return data")
-				}
-			},
-		},
-		{
-			name:     "zero TTL",
-			cacheDir: t.TempDir(),
-			enabled:  true,
-			ttl:      0,
-			testFunc: func(t *testing.T, cm *CacheManager) {
-				t.Helper()
-
-				if cm.defaultTTL != 0 {
-					t.Errorf("Expected TTL to be 0, got %v", cm.defaultTTL)
-				}
-			},
-		},
-		{
-			name:     "negative TTL",
-			cacheDir: t.TempDir(),
-			enabled:  true,
-			ttl:      -time.Hour,
-			testFunc: func(t *testing.T, cm *CacheManager) {
-				t.Helper()
-
-				if cm.defaultTTL != -time.Hour {
-					t.Errorf("Expected TTL to be -1h, got %v", cm.defaultTTL)
-				}
-			},
+			name:          "no cached data disabled",
+			enabled:       false,
+			expectedFound: false,
 		},
 	}
 
@@ -798,126 +957,42 @@ func TestNewCacheManagerComprehensiveEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cm := NewCacheManager(tt.cacheDir, tt.enabled, tt.ttl)
-			if cm == nil {
-				t.Error("Expected non-nil cache manager")
-				return
-			}
+			cm := NewCacheManager(t.TempDir(), tt.enabled, time.Hour)
 
-			if cm.enabled != tt.enabled {
-				t.Errorf("Expected enabled=%v, got %v", tt.enabled, cm.enabled)
-			}
-
-			if cm.defaultTTL != tt.ttl {
-				t.Errorf("Expected TTL=%v, got %v", tt.ttl, cm.defaultTTL)
-			}
-
-			if tt.testFunc != nil {
-				tt.testFunc(t, cm)
+			_, found := cm.GetProductsFromFullCache()
+			if found != tt.expectedFound {
+				t.Errorf("Expected found=%v, got found=%v", tt.expectedFound, found)
 			}
 		})
 	}
 }
 
+//nolint:paralleltest,tparallel // t.TempDir
 func TestCacheManagerInvalidJSON(t *testing.T) {
-	t.Parallel()
-
-	cm := NewCacheManager(t.TempDir(), true, time.Hour)
-
-	// Set invalid JSON data.
-	invalidJSON := []byte("{invalid json")
-
-	err := cm.Set("/test", invalidJSON, "test")
-	if err != nil {
-		t.Fatalf("Failed to set invalid JSON: %v", err)
-	}
-
-	// GetProductFromFullCache should handle invalid JSON gracefully.
-	_, found := cm.GetProductFromFullCache("test")
-	if found {
-		t.Error("Expected not to find product with invalid JSON")
-	}
-
-	// GetReleaseFromFullCache should handle invalid JSON gracefully.
-	_, found = cm.GetReleaseFromFullCache("test", "1.0")
-	if found {
-		t.Error("Expected not to find release with invalid JSON")
-	}
-}
-
-func TestCacheManagerGetStatsEdgeCases(t *testing.T) {
-	t.Parallel()
-
+	//nolint:govet // ok
 	tests := []struct {
-		setup    func(*testing.T) *CacheManager
-		testFunc func(*testing.T, *CacheManager)
 		name     string
+		testFunc func(*testing.T, *CacheManager)
 	}{
 		{
-			name: "disabled cache",
-			setup: func(t *testing.T) *CacheManager {
-				t.Helper()
-
-				return NewCacheManager(t.TempDir(), false, time.Hour)
-			},
+			name: "GetProductFromFullCache with invalid JSON",
 			testFunc: func(t *testing.T, cm *CacheManager) {
 				t.Helper()
 
-				stats, err := cm.GetStats()
-				if err != nil {
-					t.Errorf("GetStats should work for disabled cache: %v", err)
-				}
-				if stats.TotalFiles != 0 {
-					t.Errorf("Expected 0 files for disabled cache, got %d", stats.TotalFiles)
+				_, found := cm.GetProductFromFullCache("test")
+				if found {
+					t.Error("Expected not to find product with invalid JSON")
 				}
 			},
 		},
 		{
-			name: "empty cache directory",
-			setup: func(t *testing.T) *CacheManager {
-				t.Helper()
-
-				return NewCacheManager(t.TempDir(), true, time.Hour)
-			},
+			name: "GetReleaseFromFullCache with invalid JSON",
 			testFunc: func(t *testing.T, cm *CacheManager) {
 				t.Helper()
 
-				stats, err := cm.GetStats()
-				if err != nil {
-					t.Errorf("GetStats should work for empty cache: %v", err)
-				}
-				if stats.TotalFiles != 0 {
-					t.Errorf("Expected 0 files for empty cache, got %d", stats.TotalFiles)
-				}
-				if stats.TotalSize != 0 {
-					t.Errorf("Expected 0 size for empty cache, got %d", stats.TotalSize)
-				}
-			},
-		},
-		{
-			name: "cache with some files",
-			setup: func(t *testing.T) *CacheManager {
-				t.Helper()
-
-				cm := NewCacheManager(t.TempDir(), true, time.Hour)
-				// Add some cache entries.
-				cm.Set("/test1", []byte("test data 1"), "test1")
-				cm.Set("/test2", []byte("test data 2"), "test2")
-
-				return cm
-			},
-			testFunc: func(t *testing.T, cm *CacheManager) {
-				t.Helper()
-
-				stats, err := cm.GetStats()
-				if err != nil {
-					t.Errorf("GetStats failed: %v", err)
-				}
-				if stats.TotalFiles < 2 {
-					t.Errorf("Expected at least 2 files, got %d", stats.TotalFiles)
-				}
-				if stats.TotalSize == 0 {
-					t.Error("Expected non-zero size for cache with files")
+				_, found := cm.GetReleaseFromFullCache("test", "1.0")
+				if found {
+					t.Error("Expected not to find release with invalid JSON")
 				}
 			},
 		},
@@ -927,79 +1002,13 @@ func TestCacheManagerGetStatsEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cm := tt.setup(t)
-			tt.testFunc(t, cm)
-		})
-	}
-}
+			cm := NewCacheManager(t.TempDir(), true, time.Hour)
 
-func TestCacheManagerClearExpiredEdgeCases(t *testing.T) {
-	t.Parallel()
+			invalidJSON := []byte("{invalid json")
+			if err := cm.Set("/test", invalidJSON, "test"); err != nil {
+				t.Fatalf("Failed to set invalid JSON: %v", err)
+			}
 
-	tests := []struct {
-		setup    func(*testing.T) *CacheManager
-		testFunc func(*testing.T, *CacheManager)
-		name     string
-	}{
-		{
-			name: "disabled cache",
-			setup: func(t *testing.T) *CacheManager {
-				t.Helper()
-
-				return NewCacheManager(t.TempDir(), false, time.Hour)
-			},
-			testFunc: func(t *testing.T, cm *CacheManager) {
-				t.Helper()
-
-				err := cm.ClearExpired()
-				if err != nil {
-					t.Errorf("ClearExpired should work for disabled cache: %v", err)
-				}
-			},
-		},
-		{
-			name: "empty cache directory",
-			setup: func(t *testing.T) *CacheManager {
-				t.Helper()
-
-				return NewCacheManager(t.TempDir(), true, time.Hour)
-			},
-			testFunc: func(t *testing.T, cm *CacheManager) {
-				t.Helper()
-
-				err := cm.ClearExpired()
-				if err != nil {
-					t.Errorf("ClearExpired should work for empty cache: %v", err)
-				}
-			},
-		},
-		{
-			name: "cache with expired entries",
-			setup: func(t *testing.T) *CacheManager {
-				t.Helper()
-
-				cm := NewCacheManager(t.TempDir(), true, -time.Hour) // Negative TTL makes everything expire.
-				cm.Set("/test1", []byte("test data 1"), "test1")
-				cm.Set("/test2", []byte("test data 2"), "test2")
-
-				return cm
-			},
-			testFunc: func(t *testing.T, cm *CacheManager) {
-				t.Helper()
-
-				err := cm.ClearExpired()
-				if err != nil {
-					t.Errorf("ClearExpired failed: %v", err)
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			cm := tt.setup(t)
 			tt.testFunc(t, cm)
 		})
 	}

--- a/cmd/eol/help.txt
+++ b/cmd/eol/help.txt
@@ -19,7 +19,7 @@ Options:
   -f, --format <format>           Output format (text, json)
   -t, --template <template>       Inline template for custom output formatting
   --disable-cache                 Disable caching (ignored for --full)
-  --cache-dir <dir>               Cache directory (default: ~/.local/state/eol)
+  --cache-dir <dir>               Cache directory (default: ~/.cache/eol)
   --cache-for <duration>          Cache TTL (default: 1h, examples: 30m, 2h, 1d)
   --template-dir <dir>            Custom template directory (default: ~/.config/eol/templates)
 
@@ -49,8 +49,14 @@ Examples:
 Caching Behavior:
   Default cache: 1 hour for all endpoints except --full
   --full endpoint: Always cached for 24 hours (cannot be disabled)
-  Cache location: ~/.local/state/eol/ (configurable with --cache-dir)
-  Cache format: JSON files with expiration metadata
+  Cache location: ~/.cache/eol/ (configurable with --cache-dir)
+  Cache format: .eol_cache.json files with expiration metadata
+
+Cache Safety:
+  "cache clear" only works if the final folder name is exactly:
+    .eol-cache, eol-cache, or eol
+  Will conservatively refuse to clear folders that do not look like our own cache folder.
+  Only removes *.eol_cache.json files (no subfolders affected).
 
 Template Customization:
   eol templates                         # List available templates

--- a/coverage-badge.svg
+++ b/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="104" height="20" role="img" aria-label="coverage: 85.9%">
-  <title>coverage: 85.9%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="104" height="20" role="img" aria-label="coverage: 85.7%">
+  <title>coverage: 85.7%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="315" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text>
     <text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text>
-    <text aria-hidden="true" x="815" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">85.9%</text>
-    <text x="815" y="140" transform="scale(.1)" fill="#ffffff" textLength="330">85.9%</text>
+    <text aria-hidden="true" x="815" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">85.7%</text>
+    <text x="815" y="140" transform="scale(.1)" fill="#ffffff" textLength="330">85.7%</text>
   </g>
 </svg>

--- a/doc.go
+++ b/doc.go
@@ -98,8 +98,18 @@
 //   - Default cache TTL: 1 hour for most endpoints
 //   - ProductsFull endpoint: 24-hour cache (cannot be disabled)
 //   - Smart cache sharing: Product details can be served from ProductsFull cache
-//   - File-based cache storage in user's local state directory
+//   - File-based cache storage in ~/.cache/eol/ (follows XDG conventions)
 //   - Configurable cache directory and TTL
+//   - Cache files use .eol_cache.json extension for clear identification
+//
+// # Cache Safety
+//
+// The cache clear operation includes multiple safety layers to prevent accidental data loss:
+//
+//   - Only works if the final folder name is exactly: .eol-cache, eol-cache, or eol
+//   - Only removes *.eol_cache.json files (no subfolders affected)
+//   - Will conservatively refuse to clear folders that do not look like our own cache folder
+//   - Example safe paths: ~/.cache/eol, /var/cache/eol-cache, /tmp/.eol-cache
 //
 // # Error Handling
 //
@@ -151,6 +161,8 @@
 //	eol -t '{{.Name}}: {{.Category}}' product ubuntu  # Custom template
 //	eol --cache-for 2h product ubuntu                  # Custom cache duration
 //	eol --disable-cache latest go                      # Disable caching
+//	eol cache clear                                    # Safely clear cache
+//	eol cache stats                                    # Show cache statistics
 //
 // # Template System
 //
@@ -195,8 +207,8 @@
 //		log.Fatal(err)
 //	}
 //
-//	// Custom cache manager
-//	cacheManager := eol.NewCacheManager("/custom/cache/dir", true, time.Hour*2)
+//	// Custom cache manager (final folder name must be exactly eol, eol-cache, or .eol-cache)
+//	cacheManager := eol.NewCacheManager("/custom/cache/eol", true, time.Hour*2)
 //	client, err := eol.New(eol.WithCacheManager(cacheManager))
 //
 // For comprehensive documentation and examples, visit:

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -3,6 +3,7 @@ package eol
 import (
 	"bytes"
 	"context"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -1788,7 +1789,7 @@ func createTestClient(t *testing.T, _ context.Context, responses map[string]*moc
 	t.Helper()
 
 	mockClient := newMockClient(responses)
-	cacheManager := NewCacheManager(t.TempDir(), true, time.Hour)
+	cacheManager := NewCacheManager(filepath.Join(t.TempDir(), "eol-cache"), true, time.Hour)
 	config := &Config{Command: command, Args: args, Format: FormatText}
 
 	client, err := New(

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,7 @@
+# https://docs.socket.dev/docs/socket-yml
+version: 2
+
+projectIgnorePaths: ["tools"]
+
+githubApp:
+  enabled: true

--- a/templates_test.go
+++ b/templates_test.go
@@ -43,7 +43,6 @@ func TestTemplateManagerGetAvailableTemplates(t *testing.T) {
 
 			if tt.overrideDir != "" { //nolint:nestif // ok
 				tempDir = t.TempDir()
-				defer os.RemoveAll(tempDir)
 
 				if tt.setupUserTemplate {
 					// Create a test template file.
@@ -934,7 +933,6 @@ func TestTemplateManagerLoadFromFile(t *testing.T) {
 				return
 			default:
 				tempDir := t.TempDir()
-				defer os.RemoveAll(tempDir)
 
 				tm, err = NewTemplateManager(tempDir, "", "", nil)
 				if err != nil {
@@ -1039,7 +1037,6 @@ func TestTemplateManagerAddUserTemplates(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
-	defer os.RemoveAll(tempDir)
 
 	// Create test template files.
 	templateFiles := map[string]string{


### PR DESCRIPTION
Dropping the use of `os.RemoveAll()` to guard against potential user error (i.e. `eol cache clear --cache-dir ~/` - fat finger right there).

We now:
1. no longer delete recursively
2. no longer delete from folders that "don't look like ours"
3. even if such a folder is found, we only delete files that have the `.eol_cache.json` extension.

This should guarantee that no matter what, we only delete files that are safe to delete.