### PR TITLE
Simplified working with `IsEoas` and `IsLts`, etc. as they were `*bool` fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo "::notice title=Go Version::$(go version)"
+      # Needed until https://github.com/golang/go/issues/75031 is fixed.
+      - run: go env -w GOTOOLCHAIN=go1.25.0+auto
       - run: make test
   Lint:
     runs-on: ubuntu-latest
@@ -27,5 +29,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
+      # Needed until https://github.com/golang/go/issues/75031 is fixed.
+      - run: go env -w GOTOOLCHAIN=go1.25.0+auto
       - run: make lint
       - run: make shellcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,10 @@ name: Auto-Release
 
 on:
   push:
-    tags: ["v[0-9].[0-9]+.[0-9]+"]
+    tags: [v1.*]
+
+permissions:
+  contents: write
 
 jobs:
   Release:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-all: fmt lint actionlint vulncheck deadcode shellcheck test
-	@./test_inline_templates.sh
+all: fmt lint actionlint vulncheck deadcode shellcheck test integration-coverage
 
 build:
 	go build -o eol ./cmd
@@ -11,6 +10,14 @@ test:
 	@go test -vet all -coverprofile=unit.cov -covermode=atomic -race -count=5 $(OPTS) ./...
 	@go tool cover -func=unit.cov|tail -n1
 	@go tool -modfile=tools/go.mod stampli -quiet -coverage=$$(go tool cover -func=unit.cov|tail -n1|tr -s "\t"|cut -f3|tr -d "%")
+
+integration-coverage:
+	@echo "Running integration tests with coverage..."
+	@./test_inline_templates.sh
+
+unit.cov: test
+
+integration.cov: integration-coverage
 
 lint:
 	@go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...
@@ -44,5 +51,5 @@ coverage_map: test
 	@go tool -modfile=tools/go.mod go-cover-treemap -coverprofile unit.cov > unit.svg
 
 clean:
-	@rm -f eol eol.test *.cov
+	@rm -f eol eol.test *.cov coverage.html
 	@killall -q godoc || true

--- a/README.md
+++ b/README.md
@@ -186,6 +186,24 @@ else
 fi
 ```
 
+The `eol_within` function enables proactive EOL monitoring:
+
+```bash
+# Check for upcoming EOL within 6 months
+eol product nodejs -t '{{range .Releases}}{{if eol_within "6mo" .EolFrom}}⚠️  {{.Name}} EOLs {{.EolFrom}}{{"\n"}}{{end}}{{end}}'
+
+# Exit with error if EOL is within 30 days
+eol release ubuntu 20.04 -t '{{if eol_within "30d" .EolFrom}}URGENT: EOL in 30 days!{{exit 2}}{{end}}'
+
+# Monitor multiple releases and exit on first warning
+eol product go -t '{{range .Releases}}{{if eol_within "3mo" .EolFrom}}{{.Name}} EOLs soon: {{.EolFrom}}{{exit 1}}{{end}}{{end}}'
+
+# Use in CI/CD pipelines for dependency checks
+if eol product python -t '{{range .Releases}}{{if eol_within "12mo" .EolFrom}}{{exit 1}}{{end}}{{end}}' 2>/dev/null; then
+    echo "Python version will EOL within a year - plan migration"
+fi
+```
+
 ### Caching & Performance
 
 ```bash
@@ -397,7 +415,28 @@ Available in custom templates:
 - `default "fallback" .Field` - Default values
 - `toJSON .` - Convert to JSON
 - `slice .Releases 0 5` - Slice operations
+- `eol_within "6mo" .EolFrom` - Check if EOL is within duration (supports mo, wk, d, h, m, s)
 - `exit 1` - Exit with error code (for scripting)
+
+## Testing & Coverage
+
+The project includes comprehensive testing with both unit and integration coverage:
+
+```bash
+# Run unit tests with coverage
+make test
+
+# Run integration tests with coverage (tests actual binary execution)
+make integration-coverage
+
+# Run all tests and checks
+make all
+
+# Generate HTML coverage report
+go tool cover -html=integration.cov -o coverage.html
+```
+
+The integration tests use Go's built-in coverage instrumentation (`go build -cover`) to collect coverage data from actual binary execution, following the approach described in the [Go blog](https://go.dev/blog/integration-test-coverage).
 
 ## Contributing
 

--- a/cmd/eol/help.txt
+++ b/cmd/eol/help.txt
@@ -72,6 +72,7 @@ Template Customization:
     default "fallback" .Field           # Default values for empty fields
     toJSON .                            # Convert to JSON format
     slice .Releases 0 5                 # Slice operations
+    eol_within "6mo" .EolFrom           # Check if EOL is within duration (mo, wk, d, h, m, s)
     exit 1                              # Exit with error code (for scripting)
 
   Quick start:

--- a/coverage-badge.svg
+++ b/coverage-badge.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="104" height="20" role="img" aria-label="coverage: 85.1%">
-  <title>coverage: 85.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="104" height="20" role="img" aria-label="coverage: 85.0%">
+  <title>coverage: 85.0%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="315" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text>
     <text x="315" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text>
-    <text aria-hidden="true" x="815" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">85.1%</text>
-    <text x="815" y="140" transform="scale(.1)" fill="#ffffff" textLength="330">85.1%</text>
+    <text aria-hidden="true" x="815" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">85.0%</text>
+    <text x="815" y="140" transform="scale(.1)" fill="#ffffff" textLength="330">85.0%</text>
   </g>
 </svg>

--- a/doc.go
+++ b/doc.go
@@ -174,6 +174,7 @@
 //   - default - Provide default values
 //   - toJSON - Convert to JSON
 //   - slice - Slice operations
+//   - eol_within - Check if EOL is within duration (supports mo, wk, d, h, m, s)
 //   - exit - Exit with specific code (for scripting)
 //
 // Example template usage:
@@ -181,6 +182,8 @@
 //	eol -t '{{.Latest.Name}}' latest go
 //	eol -t '{{if .IsEol}}💀 EOL{{else}}✅ Active{{end}}' latest terraform
 //	eol -t '{{if .IsEol}}{{exit 1}}{{end}}' release ubuntu 18.04  # Exit code for scripting
+//	eol -t '{{range .Releases}}{{if eol_within "6mo" .EolFrom}}⚠️  {{.Name}} EOLs {{.EolFrom}}{{end}}{{end}}' product go
+//	eol -t '{{if eol_within "30d" .EolFrom}}URGENT: EOL in 30 days!{{exit 2}}{{end}}' release ubuntu 20.04
 //
 // # Performance Considerations
 //

--- a/endpoints.go
+++ b/endpoints.go
@@ -14,8 +14,8 @@ var (
 )
 
 // Index returns the main endoflife.date API endpoints.
-func (c *Client) Index() (r *UriListResponse, err error) {
-	r = &UriListResponse{}
+func (c *Client) Index() (r *URIListResponse, err error) {
+	r = &URIListResponse{}
 	if err = c.doRequest("/", r); err != nil {
 		return nil, fmt.Errorf("failed to get API index: %w", err)
 	}
@@ -103,8 +103,8 @@ func (c *Client) ProductLatestRelease(p string) (r *ProductReleaseResponse, err 
 }
 
 // Categories returns a list of all categories.
-func (c *Client) Categories() (r *UriListResponse, err error) {
-	r = &UriListResponse{}
+func (c *Client) Categories() (r *URIListResponse, err error) {
+	r = &URIListResponse{}
 	if err = c.doRequest("/categories", r); err != nil {
 		return nil, fmt.Errorf("failed to get categories: %w", err)
 	}
@@ -127,8 +127,8 @@ func (c *Client) ProductsByCategory(cat string) (r *ProductListResponse, err err
 }
 
 // Tags returns a list of all tags.
-func (c *Client) Tags() (r *UriListResponse, err error) {
-	r = &UriListResponse{}
+func (c *Client) Tags() (r *URIListResponse, err error) {
+	r = &URIListResponse{}
 	if err = c.doRequest("/tags", r); err != nil {
 		return nil, fmt.Errorf("failed to get tags: %w", err)
 	}
@@ -151,8 +151,8 @@ func (c *Client) ProductsByTag(tag string) (r *ProductListResponse, err error) {
 }
 
 // IdentifierTypes returns a list of all identifier types.
-func (c *Client) IdentifierTypes() (r *UriListResponse, err error) {
-	r = &UriListResponse{}
+func (c *Client) IdentifierTypes() (r *URIListResponse, err error) {
+	r = &URIListResponse{}
 	if err = c.doRequest("/identifiers", r); err != nil {
 		return nil, fmt.Errorf("failed to get identifier types: %w", err)
 	}

--- a/eol.go
+++ b/eol.go
@@ -4,8 +4,8 @@ import (
 	"time"
 )
 
-// Uri represents a link to a resource.
-type Uri struct {
+// URI represents a link to a resource.
+type URI struct {
 	Name string `json:"name"`
 	URI  string `json:"uri"`
 }
@@ -42,6 +42,29 @@ type ProductRelease struct {
 	IsLts            bool            `json:"isLts"`
 	IsMaintained     bool            `json:"isMaintained"`
 	IsEol            bool            `json:"isEol"`
+}
+
+// CliProductRelease is a CLI-friendly version of ProductRelease with regular bool fields.
+//
+//nolint:govet // ok
+type CliProductRelease struct {
+	Name             string          `json:"name"`
+	Label            string          `json:"label"`
+	ReleaseDate      string          `json:"releaseDate"`
+	IsLts            bool            `json:"isLts"`
+	IsEol            bool            `json:"isEol"`
+	IsMaintained     bool            `json:"isMaintained"`
+	IsEoas           bool            `json:"isEoas"`
+	IsDiscontinued   bool            `json:"isDiscontinued"`
+	IsEoes           bool            `json:"isEoes"`
+	EolFrom          string          `json:"eolFrom"`
+	LtsFrom          string          `json:"ltsFrom"`
+	EoasFrom         string          `json:"eoasFrom"`
+	EoesFrom         string          `json:"eoesFrom"`
+	DiscontinuedFrom string          `json:"discontinuedFrom"`
+	Codename         string          `json:"codename"`
+	Latest           *ProductVersion `json:"latest"`
+	Custom           map[string]any  `json:"custom,omitempty"`
 }
 
 // ProductSummary contains basic information about a product.
@@ -83,10 +106,10 @@ type ProductDetails struct {
 	Releases       []ProductRelease `json:"releases"`
 }
 
-// UriListResponse represents a response containing a list of URIs.
-type UriListResponse struct {
+// URIListResponse represents a response containing a list of URIs.
+type URIListResponse struct {
 	SchemaVersion string `json:"schema_version"`
-	Result        []Uri  `json:"result"`
+	Result        []URI  `json:"result"`
 	Total         int    `json:"total"`
 }
 
@@ -120,7 +143,7 @@ type ProductReleaseResponse struct {
 // IdentifierProduct represents the product reference in an identifier response.
 type IdentifierProduct struct {
 	Identifier string `json:"identifier"`
-	Product    Uri    `json:"product"`
+	Product    URI    `json:"product"`
 }
 
 // IdentifierListResponse represents a response containing identifiers for a given type.
@@ -128,4 +151,56 @@ type IdentifierListResponse struct {
 	SchemaVersion string              `json:"schema_version"`
 	Result        []IdentifierProduct `json:"result"`
 	Total         int                 `json:"total"`
+}
+
+// ToCliRelease converts a ProductRelease to a CliProductRelease with clean bool fields.
+func (pr *ProductRelease) ToCliRelease() (cli CliProductRelease) {
+	cli = CliProductRelease{
+		Name:         pr.Name,
+		Label:        pr.Label,
+		ReleaseDate:  pr.ReleaseDate,
+		IsLts:        pr.IsLts,
+		IsEol:        pr.IsEol,
+		IsMaintained: pr.IsMaintained,
+		Latest:       pr.Latest,
+		Custom:       pr.Custom,
+	}
+
+	if pr.EolFrom != nil {
+		cli.EolFrom = *pr.EolFrom
+	}
+
+	if pr.LtsFrom != nil {
+		cli.LtsFrom = *pr.LtsFrom
+	}
+
+	if pr.EoasFrom != nil {
+		cli.EoasFrom = *pr.EoasFrom
+	}
+
+	if pr.EoesFrom != nil {
+		cli.EoesFrom = *pr.EoesFrom
+	}
+
+	if pr.DiscontinuedFrom != nil {
+		cli.DiscontinuedFrom = *pr.DiscontinuedFrom
+	}
+
+	if pr.Codename != nil {
+		cli.Codename = *pr.Codename
+	}
+
+	if pr.IsEoas != nil {
+		cli.IsEoas = *pr.IsEoas
+	}
+
+	if pr.IsDiscontinued != nil {
+		cli.IsDiscontinued = *pr.IsDiscontinued
+	}
+
+	if pr.IsEoes != nil {
+		cli.IsEoes = *pr.IsEoes
+	}
+
+	return
 }

--- a/eol_test.go
+++ b/eol_test.go
@@ -13,22 +13,22 @@ func TestUriJSON(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		uri      Uri
+		uri      URI
 		expected string
 	}{
 		{
 			name:     "basic uri",
-			uri:      Uri{Name: "products", URI: "https://example.com/products"},
+			uri:      URI{Name: "products", URI: "https://example.com/products"},
 			expected: `{"name":"products","uri":"https://example.com/products"}`,
 		},
 		{
 			name:     "empty uri",
-			uri:      Uri{},
+			uri:      URI{},
 			expected: `{"name":"","uri":""}`,
 		},
 		{
 			name:     "uri with special characters",
-			uri:      Uri{Name: "test-name", URI: "https://example.com/api/v1?param=value"},
+			uri:      URI{Name: "test-name", URI: "https://example.com/api/v1?param=value"},
 			expected: `{"name":"test-name","uri":"https://example.com/api/v1?param=value"}`,
 		},
 	}
@@ -48,7 +48,7 @@ func TestUriJSON(t *testing.T) {
 			}
 
 			// Test unmarshaling.
-			var unmarshaled Uri
+			var unmarshaled URI
 
 			err = json.Unmarshal(data, &unmarshaled)
 			if err != nil {
@@ -422,10 +422,10 @@ func TestProductDetailsJSON(t *testing.T) {
 func TestUriListResponseJSON(t *testing.T) {
 	t.Parallel()
 
-	response := UriListResponse{
+	response := URIListResponse{
 		SchemaVersion: "1.2.0",
 		Total:         2,
-		Result: []Uri{
+		Result: []URI{
 			{Name: "products", URI: "https://example.com/products"},
 			{Name: "categories", URI: "https://example.com/categories"},
 		},
@@ -438,7 +438,7 @@ func TestUriListResponseJSON(t *testing.T) {
 	}
 
 	// Test unmarshaling.
-	var unmarshaled UriListResponse
+	var unmarshaled URIListResponse
 
 	err = json.Unmarshal(data, &unmarshaled)
 	if err != nil {
@@ -562,7 +562,7 @@ func TestIdentifierProductJSON(t *testing.T) {
 
 	identifierProduct := IdentifierProduct{
 		Identifier: "test-identifier",
-		Product:    Uri{Name: "go", URI: "https://example.com/go"},
+		Product:    URI{Name: "go", URI: "https://example.com/go"},
 	}
 
 	// Test marshaling.
@@ -597,7 +597,7 @@ func TestIdentifierListResponseJSON(t *testing.T) {
 		Result: []IdentifierProduct{
 			{
 				Identifier: "test-id",
-				Product:    Uri{Name: "go", URI: "https://example.com/go"},
+				Product:    URI{Name: "go", URI: "https://example.com/go"},
 			},
 		},
 	}
@@ -630,7 +630,7 @@ func TestEmptyAndNilFields(t *testing.T) {
 		name string
 		data any
 	}{
-		{"empty Uri", Uri{}},
+		{"empty Uri", URI{}},
 		{"empty Identifier", Identifier{}},
 		{"empty ProductVersion", ProductVersion{}},
 		{"empty ProductRelease", ProductRelease{}},

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alexaandru/eol
 
-go 1.24.6
+go 1.25.0

--- a/handlers.go
+++ b/handlers.go
@@ -32,22 +32,22 @@ type TypeIdentifiersResponse struct {
 
 // IndexResponse represents the API index response with available endpoints.
 type IndexResponse struct {
-	*UriListResponse
+	*URIListResponse
 }
 
 // CategoriesResponse represents a response containing available categories.
 type CategoriesResponse struct {
-	*UriListResponse
+	*URIListResponse
 }
 
 // TagsResponse represents a response containing available tags.
 type TagsResponse struct {
-	*UriListResponse
+	*URIListResponse
 }
 
 // IdentifierTypesResponse represents a response containing available identifier types.
 type IdentifierTypesResponse struct {
-	*UriListResponse
+	*URIListResponse
 }
 
 // TemplateListResponse represents a response containing available templates.
@@ -241,7 +241,7 @@ func (c *Client) HandleIndex() (err error) {
 		return
 	}
 
-	c.response = &IndexResponse{UriListResponse: response}
+	c.response = &IndexResponse{URIListResponse: response}
 	c.responseHeader = ""
 
 	return
@@ -343,13 +343,13 @@ func (c *Client) HandleLatest() (err error) {
 func (c *Client) HandleCategories() (err error) {
 	args := c.config.Args
 	if len(args) == 0 {
-		var response *UriListResponse
+		var response *URIListResponse
 
 		if response, err = c.Categories(); err != nil {
 			return
 		}
 
-		c.response = &CategoriesResponse{UriListResponse: response}
+		c.response = &CategoriesResponse{URIListResponse: response}
 	} else {
 		var response *ProductListResponse
 
@@ -371,13 +371,13 @@ func (c *Client) HandleCategories() (err error) {
 func (c *Client) HandleTags() (err error) {
 	args := c.config.Args
 	if len(args) == 0 {
-		var response *UriListResponse
+		var response *URIListResponse
 
 		if response, err = c.Tags(); err != nil {
 			return
 		}
 
-		c.response = &TagsResponse{UriListResponse: response}
+		c.response = &TagsResponse{URIListResponse: response}
 	} else {
 		var response *ProductListResponse
 
@@ -399,13 +399,13 @@ func (c *Client) HandleTags() (err error) {
 func (c *Client) HandleIdentifiers() (err error) {
 	args := c.config.Args
 	if len(args) == 0 {
-		var response *UriListResponse
+		var response *URIListResponse
 
 		if response, err = c.IdentifierTypes(); err != nil {
 			return
 		}
 
-		c.response = &IdentifierTypesResponse{UriListResponse: response}
+		c.response = &IdentifierTypesResponse{URIListResponse: response}
 	} else {
 		var response *IdentifierListResponse
 
@@ -536,13 +536,13 @@ func (c *Client) executeInlineTemplate(response any) (err error) {
 func (c *Client) extractTemplateData(response any) any {
 	switch resp := response.(type) {
 	case *IndexResponse:
-		return resp.UriListResponse
+		return resp.URIListResponse
 	case *CategoriesResponse:
-		return resp.UriListResponse
+		return resp.URIListResponse
 	case *TagsResponse:
-		return resp.UriListResponse
+		return resp.URIListResponse
 	case *IdentifierTypesResponse:
-		return resp.UriListResponse
+		return resp.URIListResponse
 	case *ProductListResponse:
 		return resp
 	case *FullProductListResponse:
@@ -550,7 +550,8 @@ func (c *Client) extractTemplateData(response any) any {
 	case *ProductResponse:
 		return &resp.Result
 	case *ProductReleaseResponse:
-		return &resp.Result
+		cli := resp.Result.ToCliRelease()
+		return &cli
 	case *CategoryProductsResponse:
 		return struct {
 			*ProductListResponse

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -973,28 +973,28 @@ func TestClientFormat(t *testing.T) {
 	}{
 		{
 			name:     "IndexResponse",
-			response: &IndexResponse{UriListResponse: &UriListResponse{}},
+			response: &IndexResponse{URIListResponse: &URIListResponse{}},
 			checkOutput: func(output []byte) bool {
 				return len(output) > 0
 			},
 		},
 		{
 			name:     "CategoriesResponse",
-			response: &CategoriesResponse{UriListResponse: &UriListResponse{}},
+			response: &CategoriesResponse{URIListResponse: &URIListResponse{}},
 			checkOutput: func(output []byte) bool {
 				return len(output) > 0
 			},
 		},
 		{
 			name:     "TagsResponse",
-			response: &TagsResponse{UriListResponse: &UriListResponse{}},
+			response: &TagsResponse{URIListResponse: &URIListResponse{}},
 			checkOutput: func(output []byte) bool {
 				return len(output) > 0
 			},
 		},
 		{
 			name:     "IdentifierTypesResponse",
-			response: &IdentifierTypesResponse{UriListResponse: &UriListResponse{}},
+			response: &IdentifierTypesResponse{URIListResponse: &URIListResponse{}},
 			checkOutput: func(output []byte) bool {
 				return len(output) > 0
 			},
@@ -1167,13 +1167,13 @@ func TestClientExtractTemplateData(t *testing.T) {
 	}{
 		{
 			name:         "IndexResponse extracts UriListResponse",
-			response:     &IndexResponse{UriListResponse: &UriListResponse{Result: []Uri{{Name: "test", URI: "/test"}}}},
-			expectedType: "*eol.UriListResponse",
+			response:     &IndexResponse{URIListResponse: &URIListResponse{Result: []URI{{Name: "test", URI: "/test"}}}},
+			expectedType: "*eol.URIListResponse",
 			checkFunc: func(t *testing.T, data any) {
 				t.Helper()
 
-				if resp, ok := data.(*UriListResponse); !ok {
-					t.Errorf("Expected *UriListResponse, got %T", data)
+				if resp, ok := data.(*URIListResponse); !ok {
+					t.Errorf("Expected *URIListResponse, got %T", data)
 				} else if len(resp.Result) != 1 || resp.Result[0].Name != "test" {
 					t.Errorf("Expected result with 'test', got %v", resp.Result)
 				}
@@ -1196,12 +1196,12 @@ func TestClientExtractTemplateData(t *testing.T) {
 		{
 			name:         "ProductReleaseResponse extracts Result field",
 			response:     &ProductReleaseResponse{Result: ProductRelease{Name: "1.21", IsLts: true}},
-			expectedType: "*eol.ProductRelease",
+			expectedType: "*eol.CliProductRelease",
 			checkFunc: func(t *testing.T, data any) {
 				t.Helper()
 
-				if resp, ok := data.(*ProductRelease); !ok {
-					t.Errorf("Expected *ProductRelease, got %T", data)
+				if resp, ok := data.(*CliProductRelease); !ok {
+					t.Errorf("Expected *CliProductRelease, got %T", data)
 				} else if resp.Name != "1.21" || !resp.IsLts {
 					t.Errorf("Expected 1.21/true, got %s/%t", resp.Name, resp.IsLts)
 				}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,12 +1,13 @@
 module tools
 
-go 1.24.6
+go 1.25.0
 
 tool (
 	github.com/alexaandru/stampli
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	github.com/nikolaydubina/go-cover-treemap
 	github.com/rhysd/actionlint/cmd/actionlint
+	github.com/wadey/gocovmerge
 	golang.org/x/tools/cmd/deadcode
 	golang.org/x/tools/cmd/godoc
 	golang.org/x/tools/cmd/goimports
@@ -198,6 +199,7 @@ require (
 	github.com/ultraware/whitespace v0.2.0 // indirect
 	github.com/uudashr/gocognit v1.2.0 // indirect
 	github.com/uudashr/iface v1.4.1 // indirect
+	github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad // indirect
 	github.com/xen0n/gosmopolitan v1.3.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yagipy/maintidx v1.0.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -439,6 +439,8 @@ github.com/uudashr/gocognit v1.2.0 h1:3BU9aMr1xbhPlvJLSydKwdLN3tEUUrzPSSM8S4hDYR
 github.com/uudashr/gocognit v1.2.0/go.mod h1:k/DdKPI6XBZO1q7HgoV2juESI2/Ofj9AcHPZhBBdrTU=
 github.com/uudashr/iface v1.4.1 h1:J16Xl1wyNX9ofhpHmQ9h9gk5rnv2A6lX/2+APLTo0zU=
 github.com/uudashr/iface v1.4.1/go.mod h1:pbeBPlbuU2qkNDn0mmfrxP2X+wjPMIQAy+r1MBXSXtg=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad h1:W0LEBv82YCGEtcmPA3uNZBI33/qF//HAAs3MawDjRa0=
+github.com/wadey/gocovmerge v0.0.0-20160331181800-b5bfa59ec0ad/go.mod h1:Hy8o65+MXnS6EwGElrSRjUzQDLXreJlzYLlWiHtt8hM=
 github.com/xen0n/gosmopolitan v1.3.0 h1:zAZI1zefvo7gcpbCOrPSHJZJYA9ZgLfJqtKzZ5pHqQM=
 github.com/xen0n/gosmopolitan v1.3.0/go.mod h1:rckfr5T6o4lBtM1ga7mLGKZmLxswUoH1zxHgNXOsEt4=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=


### PR DESCRIPTION
and handling them in text/template was "funky".

Also added a proactive "EOL checker", `eol_within(N{h,m,s,d,wk,mo})` to be able to verify what is expiring "soon" (where end users pick what soon means).